### PR TITLE
Switch to http site

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 AUTHOR = u'Ljubljana Pyramid Hackers'
 SITENAME = u'A full week of sprinting on Pyramid'
 SITESUBTITLE = u'5 to 9 December 2016, set in the beautiful Ljubljana, Slovenia'
-SITEURL = 'http://dragonsprint.com'
+SITEURL = 'https://dragonsprint.com'
 
 PATH = 'content'
 

--- a/publishconf.py
+++ b/publishconf.py
@@ -10,7 +10,7 @@ import sys
 sys.path.append(os.curdir)
 from pelicanconf import *
 
-SITEURL = 'http://dragonsprint.com'
+SITEURL = 'https://dragonsprint.com'
 RELATIVE_URLS = False
 
 FEED_ALL_ATOM = 'feeds/all.atom.xml'


### PR DESCRIPTION
Since quite some folks got the HTST headers, they're unable to use the site on HTTPS since the links still point to HTTP.

cc @zupo 