### PR TITLE
Allow right panel to scroll when the content is taller than the viewport

### DIFF
--- a/themes/backdrop/static/css/backdrop.css
+++ b/themes/backdrop/static/css/backdrop.css
@@ -7559,6 +7559,7 @@ footer {
         width: 33.3333333333%;
         float: left;
         min-height: auto;
+        overflow: auto;
         position: fixed;
         padding-left: 0.3125rem;
         right: 0;


### PR DESCRIPTION
Without this some sponsor logos are impossible to see on my laptop.